### PR TITLE
Separator between dimensions and weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-.pyc
+*.pyc

--- a/product_view.xml
+++ b/product_view.xml
@@ -13,7 +13,9 @@
                     <field name="height" attrs="{'invisible':[('type','=','service')]}"/>
                     <field name="width" attrs="{'invisible':[('type','=','service')]}"/>
                     <field name="volume_display" attrs="{'invisible':[('type','=','service')]}"/>
-                    <!--Separate the weight section from the dimensions-->
+                </field>
+                <!--Separate the weight section from the dimensions-->
+                <field name="weight" position="before">
                     <p><i><b>Weights</b></i></p><p><i><b>(kg)</b></i></p>
                 </field>
             </field>

--- a/product_view.xml
+++ b/product_view.xml
@@ -13,6 +13,8 @@
                     <field name="height" attrs="{'invisible':[('type','=','service')]}"/>
                     <field name="width" attrs="{'invisible':[('type','=','service')]}"/>
                     <field name="volume_display" attrs="{'invisible':[('type','=','service')]}"/>
+                    <!--Separate the weight section from the dimensions-->
+                    <p><i><b>Weights</b></i></p><p><i><b>(kg)</b></i></p>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Added separator as in image. Weight unit is hardcoded, as the descriptions of the weight fields reference kg.

![image](https://cloud.githubusercontent.com/assets/2587901/8180914/76425086-142a-11e5-890e-352a9e81355c.png)

Also fixed .gitignore
